### PR TITLE
Prevent Travis from building the book before the change is reviewed

### DIFF
--- a/_deploy.sh
+++ b/_deploy.sh
@@ -4,6 +4,7 @@ set -e
 
 [ -z "${GITHUB_PAT}" ] && exit 0
 [ "${TRAVIS_BRANCH}" != "master" ] && exit 0
+[ "${TRAVIS_EVENT_TYPE}" != "push" ] && exit 0
 
 git config --global user.email "ellisvalentiner@gmail.com"
 git config --global user.name "Ellis Valentiner"


### PR DESCRIPTION
This should prevent the deploy script from triggering too often; it must now be a _push_ to the master branch in order to get deployed.